### PR TITLE
model tweaks to fit predictor data format and alternate priors

### DIFF
--- a/make_stan_model_like_tobias_roth.stan
+++ b/make_stan_model_like_tobias_roth.stan
@@ -4,8 +4,8 @@ data {
   array[Nnests]int<lower=0> last_day_as_int_days; //for each of Nnests, the day it was last observed
   int<lower=0> maxage; //maximum of last
   array[Nnests, maxage]int<lower=0, upper=1> y; //indicator of alive nests
-  array[Nnests]int<lower=0> density_50m; //a covariate of the nests
-  array[Nnests]int<lower=0> snow_per;
+  vector[Nnests] density_50m; //a covariate of the nests
+  vector[Nnests] snow_per;
   int<lower=0,upper=1> use_likelihood;
 }
 
@@ -28,8 +28,8 @@ model {
   
   //priors
   b[1]~ normal(1.5,1); //the mean is on the inverse logit scale - so 1.5 is a daily survival of 0.82. 
-    b[2]~ normal(0,0.1);
-      b[3]~ normal(0,0.1);
+    b[2]~ normal(0,0.5);
+      b[3]~ normal(0,0.5);
   
   //likelihood
   if(use_likelihood){


### PR DESCRIPTION
The data assignment lines for the covariates were incorrect (integers when the data are real values).
Also adjusted the priors to encompass the values in the simulations.

with these priors, the model can generate the simulated values. However, the density covariate `b[2]` is difficult to estimate. I don't think there's anything wrong with the model. I think it reflects the fact that very few nests have `density_50m > 0`. We could confirm this potentially by extending the distance to increase the number of nests with at least one neighbour. Then re-simulate the data. 

